### PR TITLE
Add activationCommands to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "description": "A simple key-binding for aligning multi-line and multiple selections in Atom (Based on the sublime text plugin)",
   "repository": "https://github.com/Freyskeyd/atom-alignment",
   "license": "MIT",
+  "activationCommands": {
+    "atom-workspace": ["atom-alignment:align", "atom-alignment:alignMultiple"]
+  },
+  }
   "engines": {
     "atom": ">0.50.0"
   },


### PR DESCRIPTION
Tell Atom to activate the package when one of the [activationCommands](https://atom.io/docs/v0.198.0/hacking-atom-package-word-count#package-json) is called instead of on Atom load.
