### PR TITLE
Add scope-specific settings.

### DIFF
--- a/lib/atom-alignment.coffee
+++ b/lib/atom-alignment.coffee
@@ -33,17 +33,17 @@ module.exports =
                 alignLinesMultiple editor
 
 alignLines = (editor) ->
-    spaceChars       = atom.config.get 'atom-alignment.alignmentSpaceChars'
-    matcher          = atom.config.get 'atom-alignment.alignBy'
-    addSpacePostfix  = atom.config.get 'atom-alignment.addSpacePostfix'
+    spaceChars       = atom.config.get('atom-alignment.alignmentSpaceChars', scope: editor.getRootScopeDescriptor())
+    matcher          = atom.config.get('atom-alignment.alignBy',             scope: editor.getRootScopeDescriptor())
+    addSpacePostfix  = atom.config.get('atom-alignment.addSpacePostfix',     scope: editor.getRootScopeDescriptor())
     a = new Aligner(editor, spaceChars, matcher, addSpacePostfix)
     a.align(false)
     return
 
 alignLinesMultiple = (editor) ->
-    spaceChars       = atom.config.get 'atom-alignment.alignmentSpaceChars'
-    matcher          = atom.config.get 'atom-alignment.alignBy'
-    addSpacePostfix  = atom.config.get 'atom-alignment.addSpacePostfix'
+    spaceChars       = atom.config.get('atom-alignment.alignmentSpaceChars', scope: editor.getRootScopeDescriptor())
+    matcher          = atom.config.get('atom-alignment.alignBy',             scope: editor.getRootScopeDescriptor())
+    addSpacePostfix  = atom.config.get('atom-alignment.addSpacePostfix',     scope: editor.getRootScopeDescriptor())
     a = new Aligner(editor, spaceChars, matcher, addSpacePostfix)
     a.align(true)
     return


### PR DESCRIPTION
I want different alignment settings depending on the kind of file I'm editing.

For example - I want to align CSS on ```{```. But only CSS. Would look weird if I did that on JS.

Now I can.