### PR TITLE
Correct command scope to atom-text-editor (instead of atom-workspace)

### DIFF
--- a/lib/atom-alignment.coffee
+++ b/lib/atom-alignment.coffee
@@ -23,7 +23,7 @@ module.exports =
             order: 3
 
     activate: (state) ->
-        atom.commands.add 'atom-workspace',
+        atom.commands.add 'atom-text-editor',
             'atom-alignment:align': ->
                 editor = atom.workspace.getActivePaneItem()
                 alignLines editor


### PR DESCRIPTION
Hi @Freyskeyd,

This PR fixes #42, which was caused by the fact that the align commands were scoped to `atom-workspace` when they really should be scoped to `atom-text-editor`. All tests are still passing, and the package still behaves as I expect. Please consider merging this in.

**The error these changes fix:**  
![screen shot 2017-10-29 at 6 03 23 pm](https://user-images.githubusercontent.com/872474/32152488-92c958f0-bce1-11e7-9866-f4c6ad4b8c62.png)

Thanks,
Caleb